### PR TITLE
Add necessary plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,12 @@ Testing with Emacs [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
    Obviously you may modify your Emacs init file instead, if you prefer.
 
 4. Open a Dylan source file and type `M-x lsp` to start the client. The client
-   starts the LSP server (the `lsp-dylan` executable) and connects to it.
+   starts the LSP server (the `lsp-dylan` executable) and connects to it. You
+   must either `(setq dylan-lsp-exe-pathname "/absolute/path/to/lsp-dylan")` in
+   your Emacs init file or make sure that the `lsp-dylan` binary is on your
+   `PATH`.
 
-   Currently `lsp-dylan` must be in `./_build/bin/lsp-dylan` or
-   `${DYLAN}/workspaces/lsp/_build/bin/lsp-dylan`. (TODO: search for it on
-   `PATH`.)
-
-## VS Code Usage (1.45.0 on macos)
+## VS Code Usage (1.45.0 on macOS)
 
 1. Open the `vscode` folder in VS Code
 1. First time only, `npm install` to get the dependencies

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Dylan.
 
 ## Current Status
 
-As of 2021.03.14, the only function fully implemented is "jump to definition"
+As of 2022-01-04, the only function fully implemented is "jump to definition"
 and (at least in Emacs) when you jump to another `.dylan` file, that file does
 not in automatically have LSP enabled so you must use `M-x lsp` again.
 
@@ -21,7 +21,7 @@ associated with the file you're editing when you turn on LSP in your editor. It
 makes two attempts, in the following order:
 
 1. Search up in the directory structure until it finds a `workspace.json` file,
-   which indicates a [dylan-tool](https://github.com/cgay/dylan-tool)
+   which indicates a [dylan-tool](https://github.com/dylan-lang/dylan-tool)
    workspace.  In this case it looks for the "default-library" setting in the
    workspace file and opens that library.  If there is no default library set
    and there is only one "active" library, it uses that. Otherwise it fails.
@@ -37,7 +37,7 @@ makes two attempts, in the following order:
 
 Testing with Emacs [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
 
-1. Install lsp-mode (see github project page for details)
+1. Install [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
 
 2. Set environment variables.
 
@@ -53,17 +53,17 @@ Testing with Emacs [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
       Open Dylan install directory (which is not under source control) will be
       opened. For example:
 
-        export OPEN_DYLAN_USER_REGISTRIES=/home/you/lsp-dylan/registry:/home/you/opendylan/sources/registry
+        export OPEN_DYLAN_USER_REGISTRIES=/path/to/lsp-dylan/registry:/path/to/opendylan/sources/registry
 
    b. Point `OPEN_DYLAN_RELEASE_INSTALL` at the Open Dylan installation
       directory. This is necessary so that it can find the Jam build scripts,
       and core libraries. For example:
 
-        export OPEN_DYLAN_RELEASE_INSTALL=/home/you/opendylan-2021.1
+        export OPEN_DYLAN_RELEASE_INSTALL=/path/to/opendylan-2021.1
 
 3. Start emacs and make sure that `setup.el` is loaded. For example:
 
-     `emacs --load=/home/you/lsp-dylan/setup.el`
+     `emacs --load=/path/to/lsp-dylan/setup.el`
 
    Obviously you may modify your Emacs init file instead, if you prefer.
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Testing with Emacs [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
    Obviously you may modify your Emacs init file instead, if you prefer.
 
 4. Open a Dylan source file and type `M-x lsp` to start the client. The client
-   starts the LSP server (the `lsp-dylan` executable) and connects to it. You
-   must either `(setq dylan-lsp-exe-pathname "/absolute/path/to/lsp-dylan")` in
-   your Emacs init file or make sure that the `lsp-dylan` binary is on your
-   `PATH`.
+   starts the LSP server (the `dylan-lsp-server` executable) and connects to
+   it. You must either `(setq dylan-lsp-exe-pathname
+   "/absolute/path/to/dylan-lsp-server")` in your Emacs init file or make sure
+   that the `dylan-lsp-server` binary is on your `PATH`.
 
 ## VS Code Usage (1.45.0 on macOS)
 

--- a/compiler.dylan
+++ b/compiler.dylan
@@ -1,4 +1,4 @@
-Module: lsp-dylan
+Module: lsp-dylan-impl
 Synopsis: Communicaton with the Dylan command-line compiler
 Author: Peter
 Copyright: 2019

--- a/compiler.dylan
+++ b/compiler.dylan
@@ -35,8 +35,8 @@ define function open-project
                              server: server.server-context,
                              file: as(<file-locator>, name));
   let project = execute-command(command);
-  local-log("Result of opening %s is %=", name, project);
-  local-log("Result of find %s is %=",
+  log-debug("Result of opening %s is %=", name, project);
+  log-debug("Result of find %s is %=",
             project-name(project),
             find-project(project-name(project)));
   project
@@ -54,7 +54,7 @@ define function symbol-location
   if (env)
     environment-object-source-location(*project*, env)
   else
-    local-log("No environment object for %s in module %s", symbol-name, module);
+    log-debug("No environment object for %s in module %s", symbol-name, module);
   end
 end function;
 
@@ -63,7 +63,7 @@ define function list-all-package-names ()
             (dir :: <pathname>, filename :: <string>, type :: <file-type>)
           if (type == #"file")
             if (last(filename) ~= '~')
-              local-log("%s", filename);
+              log-debug("%s", filename);
             end;
           end;
         end;
@@ -82,7 +82,7 @@ define function one-off-debug ()
   let out-stream = make(<string-stream>, direction: #"output");
   let srv = start-compiler(in-stream, out-stream);
   let project = open-project(srv, "testproject");
-  local-log("Database: %=", project-compiler-database(project));
+  log-debug("Database: %=", project-compiler-database(project));
 
   *project* := project;
   *server* := srv;
@@ -94,7 +94,7 @@ define function one-off-debug ()
                                     symbol-name,
                                     library: library,
                                     module: module);
-  local-log("one-off-debug:\n  find-environment-object(%s, %s, library:%s, module:%s) => %=",
+  log-debug("one-off-debug:\n  find-environment-object(%s, %s, library:%s, module:%s) => %=",
             n(project),
             n(symbol-name),
             n(library),
@@ -105,18 +105,18 @@ define function one-off-debug ()
 //  fp := "testproject.dylan";
 //  fp := pfl;
   let (m, l) = file-module(project, fp);
-  local-log("one-off-debug:\n  1. %=\n  2. %=\n3. %=", n(fp), n(m), n(l));
+  log-debug("one-off-debug:\n  1. %=\n  2. %=\n3. %=", n(fp), n(m), n(l));
   let same? = pfl = fp;
-  local-log("one-off-debug:\n  1. %=\n  2. %=\n",
+  log-debug("one-off-debug:\n  1. %=\n  2. %=\n",
             locator-relative?(fp),
             locator-relative?(pfl));
-  local-log("one-off-debug:\n  1. %=\n  2. %=\n",
+  log-debug("one-off-debug:\n  1. %=\n  2. %=\n",
             locator-base(fp),
             locator-base(pfl));
-  local-log("one-off-debug:\n  1. %=\n  2. %=\n",
+  log-debug("one-off-debug:\n  1. %=\n  2. %=\n",
             locator-extension(fp),
             locator-extension(pfl));
-  local-log("one-off-debug:\n  1. %=\n  2. %=\n  3.%=\n",
+  log-debug("one-off-debug:\n  1. %=\n  2. %=\n  3.%=\n",
             locator-path(fp),
             locator-path(pfl),
             same?);
@@ -143,7 +143,7 @@ end;
 define function get-environment-object
     (symbol-name :: <string>, #key module) => (o :: false-or(<environment-object>))
   let library = project-library(*project*);
-  local-log("%s -> module is %s", symbol-name, n(module));
+  log-debug("%s -> module is %s", symbol-name, n(module));
   find-environment-object(*project*, symbol-name,
                           library: library,
                           module: module);

--- a/dylan-lsp-server.lid
+++ b/dylan-lsp-server.lid
@@ -1,0 +1,3 @@
+library: dylan-lsp-server
+files: server-library.dylan
+       server-main.dylan

--- a/jsonrpc.dylan
+++ b/jsonrpc.dylan
@@ -298,6 +298,10 @@ end method;
  * This is the only one implemented for now.
  */
 define class <stdio-session> (<session>)
+  constant slot input-stream :: <stream>,
+    required-init-keyword: input-stream:;
+  constant slot output-stream :: <stream>,
+    required-init-keyword: output-stream:;
 end class;
 
 define method send-raw-message
@@ -306,14 +310,14 @@ define method send-raw-message
   if (*trace-messages*)
     log-debug("send-raw-message: %s", str);
   end;
-  write-json-message(*standard-output*, str);
+  write-json-message(session.output-stream, str);
 end method;
 
 define method receive-raw-message
     (session :: <stdio-session>) => (message :: <object>)
-  read-json-message(*standard-input*)
+  read-json-message(session.input-stream)
 end method;
 
 define method flush (session :: <stdio-session>) => ()
-  force-output(*standard-output*);
+  force-output(session.output-stream);
 end method;

--- a/jsonrpc.dylan
+++ b/jsonrpc.dylan
@@ -69,9 +69,9 @@ define function json (#rest kvs) => (table :: <string-table>)
 end function;
 
 define function dump(t :: <table>) => ()
-  local-log("========== Table Dump ==========");
+  log-debug("========== Table Dump ==========");
   for (v keyed-by k in t)
-    local-log("dump: %s-->%s (%s)", k, v, object-class(v));
+    log-debug("dump: %s-->%s (%s)", k, v, object-class(v));
   end for;
 end;
 
@@ -82,7 +82,7 @@ define method read-json-message(stream :: <stream>) => (json :: <object>)
     let content-length = string-to-integer(content-length);
     let data = read(stream, content-length);
     if (*trace-messages*)
-      local-log("read-json-message: received %=", data);
+      log-debug("read-json-message: received %=", data);
     end;
     parse-json(data);
   else
@@ -223,7 +223,7 @@ define method send-notification(session :: <session>,
   end;
   send-raw-message(session, message);
   if (*trace-messages*)
-    local-log("send-notification: %=", method-name);
+    log-debug("send-notification: %=", method-name);
   end;
 end method;
 
@@ -246,7 +246,7 @@ define method receive-message (session :: <session>)
       else
         // Received a response
         if (*trace-messages*)
-          local-log("receive-message: got id %=", id);
+          log-debug("receive-message: got id %=", id);
         end;
         let func = element(session.callbacks, id, default: #f);
         if (func)
@@ -274,7 +274,7 @@ define method send-request (session :: <session>,
   end if;
   send-raw-message(session, message);
   if (*trace-messages*)
-    local-log("send-request: %s", print-json-to-string(message));
+    log-debug("send-request: %s", print-json-to-string(message));
   end if;
 end method;
 
@@ -286,7 +286,7 @@ define method send-response(session :: <session>,
   message["result"] := result;
   send-raw-message(session, message);
   if (*trace-messages*)
-    local-log("send-response: %s", print-json-to-string(message));
+    log-debug("send-response: %s", print-json-to-string(message));
   end if;
 end method;
 
@@ -305,7 +305,7 @@ define method send-error-response(session :: <session>,
   message["error"] := params;
   send-raw-message(session, message);
   if (*trace-messages*)
-    local-log("send-error-response: %s", print-json-to-string(message));
+    log-debug("send-error-response: %s", print-json-to-string(message));
   end;
 end method;
 
@@ -321,7 +321,7 @@ define method send-raw-message(session :: <stdio-session>,
     => ()
   let str :: <string> = print-json-to-string(message);
   if (*trace-messages*)
-    local-log("send-raw-message: %s", str);
+    log-debug("send-raw-message: %s", str);
   end;
   write-json-message(*standard-output*, str);
 end method;

--- a/jsonrpc.dylan
+++ b/jsonrpc.dylan
@@ -1,4 +1,4 @@
-Module: lsp-dylan
+Module: lsp-dylan-impl
 Synopsis: Support routines for json-rpc
 Author: Peter
 Copyright: 2020

--- a/library.dylan
+++ b/library.dylan
@@ -24,12 +24,21 @@ define library lsp-dylan
   use strings;
   use system;
   use workspaces;
+
+  export
+    lsp-dylan,
+    lsp-dylan-impl;
 end library;
 
 define module lsp-dylan
+  create
+    lsp-server-top-level;
+end module;
+
+define module lsp-dylan-impl
+  use lsp-dylan;
+
   use build-system;
-  use command-line-parser,
-    prefix: "clp/";
   use command-lines;
   use commands;
   use common-dylan;
@@ -57,4 +66,8 @@ define module lsp-dylan
   use threads;
   use workspaces,
     prefix: "ws/";
-end module lsp-dylan;
+
+  // For test suite.
+  export
+    send-request;
+end module;

--- a/library.dylan
+++ b/library.dylan
@@ -69,5 +69,10 @@ define module lsp-dylan-impl
 
   // For test suite.
   export
-    send-request;
+    id,
+    json,
+    send-raw-message,
+    send-request,
+    <stdio-session>,
+      output-stream;
 end module;

--- a/lsp-dylan.dylan
+++ b/lsp-dylan.dylan
@@ -714,7 +714,9 @@ define function lsp-server-top-level
   if (debug-opendylan?)
     enable-od-environment-debug-logging();
   end;
-  let session = make(<stdio-session>);
+  let session = make(<stdio-session>,
+                     input-stream: *standard-input*,
+                     output-stream: *standard-output*);
   block ()
     lsp-pre-init-state-loop(session);
     lsp-active-state-loop(session);

--- a/lsp-dylan.dylan
+++ b/lsp-dylan.dylan
@@ -446,7 +446,7 @@ define function find-workspace-root
       elseif (root-path)
         as(<directory-locator>, root-path)
       end;
-  let workspace = ws/workspace-file() & ws/find-workspace(directory: directory);
+  let workspace = ws/find-workspace-file(directory) & ws/load-workspace(directory);
   if (workspace)
     ws/workspace-directory(workspace)
   else
@@ -591,9 +591,9 @@ define function find-project-name
     // We've set it explicitly
     local-log("Project name explicitly:%s", *project-name*);
     *project-name*
-  elseif (ws/workspace-file())
+  elseif (ws/find-workspace-file(working-directory()))
     // There's a dylan-tool workspace.
-    let workspace = ws/find-workspace();
+    let workspace = ws/load-workspace(working-directory());
     let library-name = workspace & ws/workspace-default-library-name(workspace);
     if (library-name)
       local-log("found dylan-tool workspace default library name %=", library-name);

--- a/lsp-dylan.dylan
+++ b/lsp-dylan.dylan
@@ -20,7 +20,7 @@ define constant $log
                        $lsp-log-target));
 
 define function local-log(m :: <string>, #rest params) => ()
-  apply(log-debug, m, params);
+  apply(log-info, m, params);
 end function;
 
 define constant $message-type-error = 1;

--- a/lsp-internal.dylan
+++ b/lsp-internal.dylan
@@ -1,4 +1,4 @@
-Module: lsp-dylan
+Module: lsp-dylan-impl
 Synopis: General constants and globals for LSP
 Author: Peter
 Copyright: 2020

--- a/lsp-internal.dylan
+++ b/lsp-internal.dylan
@@ -25,8 +25,8 @@ let $unknown-error-code :: <integer> = -32001;
 let $request-cancelled :: <integer> = -32800;
 let $content-modified :: <integer> = -32801;
 
-define function default-error-message(code :: <integer>)
-    => (message :: <string>)
+define function default-error-message
+    (code :: <integer>) => (message :: <string>)
   select (code)
     $parse-error => "Parse error";
     $invalid-request => "Invalid request";

--- a/pkg.json
+++ b/pkg.json
@@ -1,6 +1,7 @@
 {
     "name": "lsp-dylan",
     "deps": [
+        "command-line-parser@3.1",
         "json@1.0",
         "logging@2.1",
         "vscode-dylan@0.1",

--- a/pkg.json
+++ b/pkg.json
@@ -1,9 +1,10 @@
 {
     "name": "lsp-dylan",
     "deps": [
-        "json head",
-        "logging head",
-        "vscode-dylan head"
+        "json@1.0",
+        "logging@2.1",
+        "vscode-dylan@0.1",
+        "workspaces@0.3"
     ],
-    "location": "git@github.com:pedro-w/lsp-dylan"
+    "location": "https://github.com/dylan-lang/lsp-dylan"
 }

--- a/server-library.dylan
+++ b/server-library.dylan
@@ -1,0 +1,13 @@
+Module: dylan-user
+
+define library dylan-lsp-server
+  use common-dylan;
+  use command-line-parser;
+  use lsp-dylan;
+end library;
+
+define module dylan-lsp-server
+  use common-dylan;
+  use command-line-parser;
+  use lsp-dylan;
+end module;

--- a/server-main.dylan
+++ b/server-main.dylan
@@ -1,0 +1,26 @@
+Module: dylan-lsp-server
+
+define command-line <lsp-server-command-line> ()
+  option debug-server? :: <boolean> = #t, // default to #f eventually
+    names: #("debug-server"),
+    kind: <flag-option>,
+    help: "Turn on debugging for the LSP server.";
+  option debug-opendylan? :: <boolean> = #t, // default to #f eventually
+    names: #("debug-opendylan"),
+    kind: <flag-option>,
+    help: "Turn on debugging for Open Dylan.";
+end command-line;
+
+define function main
+    (name :: <string>, arguments :: <vector>)
+  let command = make(<lsp-server-command-line>, help: "Dylan LSP server");
+  block ()
+    parse-command-line(command, application-arguments());
+    lsp-server-top-level(debug-server?: command.debug-server?,
+                         debug-opendylan?: command.debug-opendylan?);
+  exception (err :: <abort-command-error>)
+    exit-application(exit-status(err));
+  end;
+end function;
+
+main(application-name(), application-arguments());

--- a/setup.el
+++ b/setup.el
@@ -6,16 +6,16 @@
 (setq lsp-enable-snippet nil)
 (setq lsp-server-trace "verbose")
 
-(defvar dylan-lsp-exe-pathname "lsp-dylan"
-  "Pathname of the lsp-dylan executable. Must be an absolute pathname
+(defvar dylan-lsp-exe-pathname "dylan-lsp-server"
+  "Name of the dylan-lsp-server executable. Must be an absolute pathname
    or the binary must be on your PATH.")
 
 (defvar dylan-lsp-debug-server t
-  "If true, the --debug-server option is passed to lsp-dylan, which
-   causes extra debug output from lsp-dylan in the *dylan-lsp* buffer.")
+  "If true, the --debug-server option is passed to dylan-lsp-server, which
+   causes extra debug output from dylan-lsp-server in the *dylan-lsp* buffer.")
 
 (defvar dylan-lsp-debug-opendylan t
-  "If true, the --debug-opendylan option is passed to lsp-dylan, which
+  "If true, the --debug-opendylan option is passed to dylan-lsp-server, which
    causes extra debug output from Open Dylan in the *dylan-lsp* buffer.")
 
 (add-to-list 'lsp-language-id-configuration '(dylan-mode . "dylan"))

--- a/tests/jsonrpc.dylan
+++ b/tests/jsonrpc.dylan
@@ -1,5 +1,12 @@
 Module: lsp-dylan-test-suite
 
 define test test-send-request ()
-  assert-equal(send-request, send-request); // TODO
+  let session = make(<stdio-session>,
+                     input-stream: make(<string-stream>),
+                     output-stream: make(<string-stream>, direction: #"output"));
+  send-request(session, "MakeWhirledPeas", json("param1", 1));
+  assert-equal(1, session.id);
+  let output = session.output-stream.stream-contents;
+  assert-true(starts-with?(output, "Content-Length: "));
+  assert-true(find-substring(output, "param1"));
 end test;

--- a/tests/jsonrpc.dylan
+++ b/tests/jsonrpc.dylan
@@ -1,0 +1,5 @@
+Module: lsp-dylan-test-suite
+
+define test test-send-request ()
+  assert-equal(send-request, send-request); // TODO
+end test;

--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -1,0 +1,13 @@
+Module: dylan-user
+
+define library lsp-dylan-test-suite
+  use common-dylan;
+  use testworks;
+  use lsp-dylan;
+end library;
+
+define module lsp-dylan-test-suite
+  use common-dylan;
+  use testworks;
+  use lsp-dylan-impl;
+end module;

--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -2,12 +2,16 @@ Module: dylan-user
 
 define library lsp-dylan-test-suite
   use common-dylan;
-  use testworks;
+  use io;
   use lsp-dylan;
+  use strings;
+  use testworks;
 end library;
 
 define module lsp-dylan-test-suite
   use common-dylan;
-  use testworks;
   use lsp-dylan-impl;
+  use streams;
+  use strings;
+  use testworks;
 end module;

--- a/tests/lsp-dylan-test-suite.dylan
+++ b/tests/lsp-dylan-test-suite.dylan
@@ -1,0 +1,3 @@
+Module: lsp-dylan-test-suite
+
+run-test-application()

--- a/tests/lsp-dylan-test-suite.lid
+++ b/tests/lsp-dylan-test-suite.lid
@@ -1,0 +1,4 @@
+Library: lsp-dylan-test-suite
+Files: library.dylan
+       jsonrpc.dylan
+       lsp-dylan-test-suite.dylan


### PR DESCRIPTION
This branch is called "simplify", but of course things change. I'm instead getting basic infrastructure in place and cleaning up before working on more features.

* added a test suite with a single test
* separated into a library (`lsp-dylan`) and an executable (`dylan-lsp-server`); necessary for the test suite to not start the main server loop.
* brought a bit into line with common dylan style.
* cleaned up logging (more to be done here)
* updated dependencies (it's highly likely that building with submodules is broken by now)
* some doc updates