### PR TITLE
Hover implementation

### DIFF
--- a/compiler.dylan
+++ b/compiler.dylan
@@ -42,10 +42,20 @@ define function open-project
   project
 end function;
 
-
-define function describe-symbol (symbol-name)
-  let env = get-environment-object(symbol-name, module: *module*);
-  environment-object-description(*project*, env, *module*)
+// Get a symbol's description from the compiler database.
+// This is used to implement the 'hover' function.
+//
+// Parameters:
+//  symbol-name - a <string>
+//  module - a <module-object> or #f
+// Returns:
+//  description - a <string> or #f
+define function describe-symbol
+    (symbol-name :: <string>, #key module) => (description :: false-or(<string>))
+  let env = get-environment-object(symbol-name, module: module);
+  if (env) 
+    environment-object-description(*project*, env, module)
+  end if;
 end;
 
 define function symbol-location

--- a/compiler.dylan
+++ b/compiler.dylan
@@ -53,7 +53,7 @@ end function;
 define function describe-symbol
     (symbol-name :: <string>, #key module) => (description :: false-or(<string>))
   let env = get-environment-object(symbol-name, module: module);
-  if (env) 
+  if (env)
     environment-object-description(*project*, env, module)
   end if;
 end;

--- a/lsp-dylan.dylan
+++ b/lsp-dylan.dylan
@@ -198,12 +198,12 @@ end handler;
 define function format-hover-message
     (txt :: false-or(<string>)) => (hover :: false-or(<string>))
   if (txt)
-    let lines = split-lines(txt);
-    if (size(lines) = 4)
-      let fname = strip(lines[1]);
-      let params = strip(lines[2]);
-      let returns = strip(lines[3]);
-      format-to-string("%s %s %s", fname, params, returns)
+    let (_, fname, params, returns) = apply(values, split-lines(txt));
+    if (returns)
+      format-to-string("%s %s %s",
+                       strip(fname),
+                       strip(params),
+                       strip(returns))
     end if;
   end if;
 end function;


### PR DESCRIPTION
This is a simple implementation of the `textDocument/hover` operation. The information comes from the `environment-object-description` implemented by the compiler. It is shortened to just show "kind method (params) => return", where kind is method or generic. Having longer hover texts seems to be the norm on VS Code but i found them quite intrusive on emacs.