### PR TITLE
Improve emacs client

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Testing with Emacs [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
 
    b. The server needs the Open Dylan installation directory, so it
       can find the Jam build scripts and core libraries. If
-      `dylan-compiler` is on the path, the emacs client will find
+      `dylan-compiler` is on the path, the emacs client will find the
       installation directory relative to that. To override it, either
       set the emacs variable `dylan-lsp-open-dylan-release` (using the
       customization interface) or set the environment variable

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ makes two attempts, in the following order:
 
 Testing with Emacs [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
 
-1. Install [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
+1. Install [lsp-mode](https://github.com/emacs-lsp/lsp-mode) and Dylan mode. 
+   Both these are available from MELPA.
 
 2. Set environment variables.
 
@@ -55,11 +56,17 @@ Testing with Emacs [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
 
         export OPEN_DYLAN_USER_REGISTRIES=/path/to/lsp-dylan/registry:/path/to/opendylan/sources/registry
 
-   b. Point `OPEN_DYLAN_RELEASE_INSTALL` at the Open Dylan installation
-      directory. This is necessary so that it can find the Jam build scripts,
-      and core libraries. For example:
+   b. The server needs the Open Dylan installation directory, so it
+      can find the Jam build scripts and core libraries. If
+      `dylan-compiler` is on the path, the emacs client will find
+      installation directory relative to that. To override it, either
+      set the emacs variable `dylan-lsp-open-dylan-release` (using the
+      customization interface) or set the environment variable
+      `OPEN_DYLAN_RELEASE_INSTALL`. For example:
 
-        export OPEN_DYLAN_RELEASE_INSTALL=/path/to/opendylan-2021.1
+          export OPEN_DYLAN_RELEASE_INSTALL=/path/to/opendylan-2021.1
+
+      The emacs variable takes priority if both are set.
 
 3. Start emacs and make sure that `setup.el` is loaded. For example:
 
@@ -72,6 +79,16 @@ Testing with Emacs [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
    it. You must either `(setq dylan-lsp-exe-pathname
    "/absolute/path/to/dylan-lsp-server")` in your Emacs init file or make sure
    that the `dylan-lsp-server` binary is on your `PATH`.
+   
+The emacs client has a customization group "Dylan Lsp" which is a member of the "Programming 
+/ Tools" group, and has the following variables:
+
+* `dylan-lsp-exe-pathname`
+* `dylan-lsp-debug-server`
+* `dylan-lsp-debug-opendylan`
+* `dylan-lsp-log-pathname`
+
+These are documented in the customization interface within emacs.
 
 ## Visual Studio Code Usage
 

--- a/setup.el
+++ b/setup.el
@@ -17,13 +17,15 @@
    Must be an absolute pathname or the binary must be on your PATH."
   :type 'string)
 
-(defcustom dylan-lsp-debug-server t
+(defcustom dylan-lsp-debug-server-flag t
   "Display extra debugging info from the server.
    If true, the --debug-server option is passed to dylan-lsp-server, which
-   causes extra debug output from dylan-lsp-server in the *dylan-lsp* buffer."
+   causes extra debug output from dylan-lsp-server in the *dylan-lsp* buffer.
+   This will also cause the server to crash with a backtrace, if a message
+   handler encounters an error."
   :type 'boolean)
 
-(defcustom dylan-lsp-debug-opendylan t
+(defcustom dylan-lsp-debug-opendylan-flag t
   "Display extra debugging info from the compiler.
    If true, the --debug-opendylan option is passed to dylan-lsp-server, which
    causes extra debug output from Open Dylan in the *dylan-lsp* buffer."
@@ -48,13 +50,15 @@
   "Generate the command line to start the LSP server"
   (append
    (list dylan-lsp-exe-pathname)
-   (when dylan-lsp-debug-server '("--debug-server"))
-   (when dylan-lsp-debug-opendylan '("--debug-opendylan"))
+   (when dylan-lsp-debug-server-flag '("--debug-server"))
+   (when dylan-lsp-debug-opendylan-flag '("--debug-opendylan"))
    (when dylan-lsp-log-pathname (list "--log" dylan-lsp-log-pathname))))
 
 (defun dylan-lsp--infer-install-dir ()
   "Find the install dir relative to `dylan-compiler' on the path"
-  (let* ((compiler (executable-find "dylan-compiler"))
+  (let* ((compiler (or
+		    (executable-find "dylan-compiler")
+		    (error "Cannot find the Dylan install directory; dylan-compiler must be on the PATH")))
 	 (bindir (file-name-directory compiler))
 	 (bindirname (directory-file-name bindir))
 	 (installdir (file-name-directory bindirname)))

--- a/setup.el
+++ b/setup.el
@@ -1,42 +1,85 @@
 ;;; Configuration for the Dylan LSP server.
 
 (require 'lsp-mode)
+(require 'dylan)
 
 (setq lsp-log-io t)
 (setq lsp-enable-snippet nil)
 (setq lsp-server-trace "verbose")
 
-(defvar dylan-lsp-exe-pathname "dylan-lsp-server"
-  "Name of the dylan-lsp-server executable. Must be an absolute pathname
-   or the binary must be on your PATH.")
+(defgroup dylan-lsp nil
+  "Options controlling the Dylan LSP server."
+  :group 'tools
+  :prefix "dylan-lsp-")
 
-(defvar dylan-lsp-debug-server t
-  "If true, the --debug-server option is passed to dylan-lsp-server, which
-   causes extra debug output from dylan-lsp-server in the *dylan-lsp* buffer.")
+(defcustom dylan-lsp-exe-pathname "dylan-lsp-server"
+  "Name of the dylan-lsp-server executable.
+   Must be an absolute pathname or the binary must be on your PATH."
+  :type 'string)
 
-(defvar dylan-lsp-debug-opendylan t
-  "If true, the --debug-opendylan option is passed to dylan-lsp-server, which
-   causes extra debug output from Open Dylan in the *dylan-lsp* buffer.")
+(defcustom dylan-lsp-debug-server t
+  "Display extra debugging info from the server.
+   If true, the --debug-server option is passed to dylan-lsp-server, which
+   causes extra debug output from dylan-lsp-server in the *dylan-lsp* buffer."
+  :type 'boolean)
 
-(defvar dylan-lsp-log-pathname nil
-  "Pathname of the server's log file. The default is dylan-lsp-server.log, in
-   the server's working directory, which is normally the directory of the
-   Dylan source file where the LSP client was started.")
+(defcustom dylan-lsp-debug-opendylan t
+  "Display extra debugging info from the compiler.
+   If true, the --debug-opendylan option is passed to dylan-lsp-server, which
+   causes extra debug output from Open Dylan in the *dylan-lsp* buffer."
+  :type 'boolean)
+
+(defcustom dylan-lsp-log-pathname nil
+  "Pathname of the server's log file.
+   The default is dylan-lsp-server.log, in the server's working directory,
+   which is normally the directory of the Dylan source file where the LSP
+   client was started."
+  :type 'file)
+
+(defcustom dylan-lsp-open-dylan-release nil
+  "Absolute pathname of the Open Dylan installation directory.
+   If nil, infer the installation directory from the location
+   of the dylan-compiler binary, which must be on the path."
+  :type '(choice string (const nil)))
 
 (add-to-list 'lsp-language-id-configuration '(dylan-mode . "dylan"))
 
-(defun dylan-lsp-start ()
-  (let* ((full-path dylan-lsp-exe-pathname)
-         (server (list full-path)))
-    (when dylan-lsp-debug-server
-      (setq server (append server '("--debug-server"))))
-    (when dylan-lsp-debug-opendylan
-      (setq server (append server '("--debug-opendylan"))))
-    (when dylan-lsp-log-pathname
-      (setq server (append server (list "--log" dylan-lsp-log-pathname))))
-    (lsp-register-client
-     (make-lsp-client :new-connection (lsp-stdio-connection server)
-                      :major-modes '(dylan-mode)
-                      :server-id 'dylan-lsp))))
+(defun dylan-lsp--command ()
+  "Generate the command line to start the LSP server"
+  (append
+   (list dylan-lsp-exe-pathname)
+   (when dylan-lsp-debug-server '("--debug-server"))
+   (when dylan-lsp-debug-opendylan '("--debug-opendylan"))
+   (when dylan-lsp-log-pathname (list "--log" dylan-lsp-log-pathname))))
 
-(dylan-lsp-start)
+(defun dylan-lsp--infer-install-dir ()
+  "Find the install dir relative to `dylan-compiler' on the path"
+  (let* ((compiler (executable-find "dylan-compiler"))
+	 (bindir (file-name-directory compiler))
+	 (bindirname (directory-file-name bindir))
+	 (installdir (file-name-directory bindirname)))
+    installdir))
+
+(defun dylan-lsp--environment ()
+  "Generate the environment vars to pass to the server."
+  ;; Currently OPEN_DYLAN_RELEASE_INSTALL is the only one
+  (let ((dotemacs (and (boundp 'dylan-lsp-open-dylan-release)
+		       (not (string= "" dylan-lsp-open-dylan-release))
+		       dylan-lsp-open-dylan-release))
+	(env (getenv "OPEN_DYLAN_RELEASE_INSTALL")))
+    (list
+     ;; Take value from first of .emacs, the environment, or inferred 
+     (cons "OPEN_DYLAN_RELEASE_INSTALL" (or dotemacs
+					    env
+					    (dylan-lsp--infer-install-dir))))))
+
+(defun dylan-lsp--start ()
+  "Do whatever we need to set up and register with emacs-lsp"
+  (lsp-register-client
+   (make-lsp-client :new-connection (lsp-stdio-connection 'dylan-lsp--command)
+		    :environment-fn 'dylan-lsp--environment
+		    :major-modes '(dylan-mode)
+		    :server-id 'dylan-lsp)))
+
+(dylan-lsp--start)
+

--- a/setup.el
+++ b/setup.el
@@ -73,13 +73,18 @@
 					    env
 					    (dylan-lsp--infer-install-dir))))))
 
+(defun dylan-lsp--initialized (workspace)
+  "Event handler for when the connection is initialized")
+
 (defun dylan-lsp--start ()
   "Do whatever we need to set up and register with emacs-lsp"
   (lsp-register-client
    (make-lsp-client :new-connection (lsp-stdio-connection 'dylan-lsp--command)
 		    :environment-fn 'dylan-lsp--environment
 		    :major-modes '(dylan-mode)
+		    :initialized-fn 'dylan-lsp--initialized
 		    :server-id 'dylan-lsp)))
 
+(lsp-consistency-check dylan-lsp)
 (dylan-lsp--start)
 


### PR DESCRIPTION
This reduces the amount of config that needs to be done, hopefully to nothing as long as both dylan-compiler and dylan-lsp-server are on the path.