### PR TITLE
Improve textDocument/definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,18 @@ Dylan.
 
 ## Current Status
 
-As of 2022-01-04, the only function fully implemented is "jump to definition"
-and (at least in Emacs) when you jump to another `.dylan` file, that file does
+As of 2022-09-07, the server implements
+
+* Jump to declaration
+* Jump to definition
+* Hover
+
+When applied to a symbol which is bound to a generic function, "jump to 
+definition" will show a clickable list containing the generic function and 
+its specific methods, whereas "jump to declaration" will jump straight to 
+the generic function.
+
+In Emacs, when you jump to another `.dylan` file, that file does
 not in automatically have LSP enabled so you must use `M-x lsp` again.
 
 We are currently using version [3.15 of the LSP protocol](https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/).

--- a/compiler.dylan
+++ b/compiler.dylan
@@ -47,7 +47,7 @@ end function;
 // For anything else it's the thing itself
 // Returns a list of <definition-object>s
 define generic all-definitions
-  (server :: <server>, object :: <definition-object>) => (definitions :: <list>);
+  (server :: <server>, object :: <definition-object>) => (definitions :: <sequence>);
 
 // Get a symbol's description from the compiler database.
 // This is used to implement the 'hover' function.
@@ -73,7 +73,7 @@ define function symbol-locations
     map(method(definition) environment-object-source-location(*project*, definition) end, all);
   else
     log-debug("No environment object for %s in module %s", symbol-name, module);
-    list();
+    #();
   end
 end function;
 
@@ -171,17 +171,16 @@ end function;
 // For most definition objects it's just a list with the thing itself
 define method all-definitions
     (server :: <server>, object :: <definition-object>) => (definitions :: <list>)
-    list(object);
+  list(object);
 end;
 
 // For GF it's the GF at the head of the list and all the specialising
 // methods in the tail.
 define method all-definitions
     (server :: <server>, gf :: <generic-function-object>) => (definitions :: <list>)
-  let definitions = list();
-  local method add(meth)
-          definitions := pair(meth, definitions);
-        end;
-  do-generic-function-methods(add, server, gf, client: #f);
+  let definitions = #();
+  do-generic-function-methods(method(meth)
+                                  definitions := pair(meth, definitions);
+                              end, server, gf, client: #f);
   pair(gf, definitions);
 end;


### PR DESCRIPTION
The `textDocument/definition` command (M-. in emacs) now shows a list when applied to a symbol which is bound to a generic function. The first item is the generic function itself and the rest are the specific methods. The user can choose and jump to any. For other symbols it will jump to the one and only definition.

This PR also adds support for `textDocument/declaration` which jumps directly to the generic function declaration.

This will need extensive testing! 